### PR TITLE
Show positive nanosecond for dates prior 1970-01-01.

### DIFF
--- a/src/timezone.js
+++ b/src/timezone.js
@@ -249,7 +249,7 @@
     , j: function (date) { return Math.floor((date.getTime() - Date.UTC(date.getUTCFullYear(), 0)) / 864e5) + 1 }
     , s: function (date) { return Math.floor(date.getTime() / 1000) }
     , C: function (date) { return Math.floor(date.getUTCFullYear() / 100) }
-    , N: function (date) { return date.getTime() % 1000 * 1000000 }
+    , N: function (date) { return nanoSubSeconds(date) }
     , m: function (date) { return date.getUTCMonth() + 1 }
     , Y: function (date) { return date.getUTCFullYear() }
     , y: function (date) { return date.getUTCFullYear() % 100 }
@@ -311,6 +311,11 @@
   context.k.style = "_";
   context.l.style = "_";
   context.e.style = "_";
+
+  function nanoSubSeconds(date) {
+    var ms = (date.getTime() % 1000 + 1000) % 1000;
+    return ms * 1e6;
+  }
 
   function weekOfYear (date, startOfWeek) {
     var diff, nyd, weekStart;

--- a/src/timezone.js
+++ b/src/timezone.js
@@ -249,7 +249,7 @@
     , j: function (date) { return Math.floor((date.getTime() - Date.UTC(date.getUTCFullYear(), 0)) / 864e5) + 1 }
     , s: function (date) { return Math.floor(date.getTime() / 1000) }
     , C: function (date) { return Math.floor(date.getUTCFullYear() / 100) }
-    , N: function (date) { return nanoSubSeconds(date) }
+    , N: function (date) { return ((date.getTime() % 1000 + 1000) % 1000) * 1000000 }
     , m: function (date) { return date.getUTCMonth() + 1 }
     , Y: function (date) { return date.getUTCFullYear() }
     , y: function (date) { return date.getUTCFullYear() % 100 }
@@ -311,11 +311,6 @@
   context.k.style = "_";
   context.l.style = "_";
   context.e.style = "_";
-
-  function nanoSubSeconds(date) {
-    var ms = (date.getTime() % 1000 + 1000) % 1000;
-    return ms * 1e6;
-  }
 
   function weekOfYear (date, startOfWeek) {
     var diff, nyd, weekStart;

--- a/t/format/nanoseconds.t.js
+++ b/t/format/nanoseconds.t.js
@@ -1,8 +1,9 @@
-require('proof')(3, prove)
+require('proof')(4, prove)
 
 function prove (assert) {
     var tz = require('timezone'), util = require('../util')
     assert(tz(util.y2k, '%N'), '000000000', 'top of hour')
     assert(tz(util.utc(1980, 0, 1, 0, 0, 1, 999), '%N'), '999000000', 'last millisecond')
     assert(tz(util.utc(1980, 0, 1, 0, 0, 1, 3), '%N'), '003000000', 'nanoseconds')
+    assert(tz(util.utc(1969, 0, 1, 0, 0, 1, 42), '%N'), '042000000', 'ns from negative')
 }


### PR DESCRIPTION
JavaScript modulo operator calculates a negative remainder if the dividend becomes negative. Thus current implementation renders signed nanoseconds on `%N` directive for negative timestamps, i.e. dates prior 1970-01-01:

```javascript
var d = '1969-12-31 23:59:59.100'
var utc = tz(d) // -900
tz(utc, '%Y-%m-%d %H:%M:%S.%3N')
// -> "1969-12-31 22:59:59.-90"
```