### PR TITLE
feat: Add meridiems based on default AM/PM output

### DIFF
--- a/src/locales/ast_ES.js
+++ b/src/locales/ast_ES.js
@@ -51,8 +51,8 @@ module.exports = {
     ]
   },
   "meridiem": [
-    "",
-    ""
+    "AM",
+    "PM"
   ],
   "date": "%d/%m/%y",
   "time24": "%T",

--- a/src/locales/bg_BG.js
+++ b/src/locales/bg_BG.js
@@ -51,8 +51,8 @@ module.exports = {
     ]
   },
   "meridiem": [
-    "",
-    ""
+    "AM",
+    "PM"
   ],
   "date": "%e.%m.%Y",
   "time24": "%k,%M,%S",

--- a/src/locales/ca_ES.js
+++ b/src/locales/ca_ES.js
@@ -51,8 +51,8 @@ module.exports = {
     ]
   },
   "meridiem": [
-    "",
-    ""
+    "AM",
+    "PM"
   ],
   "date": "%d/%m/%y",
   "time24": "%T",

--- a/src/locales/cs_CZ.js
+++ b/src/locales/cs_CZ.js
@@ -51,8 +51,8 @@ module.exports = {
     ]
   },
   "meridiem": [
-    "",
-    ""
+    "AM",
+    "PM"
   ],
   "date": "%-d.%-m.%Y",
   "time24": "%H:%M:%S",

--- a/src/locales/de_AT.js
+++ b/src/locales/de_AT.js
@@ -51,8 +51,8 @@ module.exports = {
     ]
   },
   "meridiem": [
-    "",
-    ""
+    "AM",
+    "PM"
   ],
   "date": "%Y-%m-%d",
   "time24": "%T",

--- a/src/locales/de_CH.js
+++ b/src/locales/de_CH.js
@@ -51,8 +51,8 @@ module.exports = {
     ]
   },
   "meridiem": [
-    "",
-    ""
+    "AM",
+    "PM"
   ],
   "date": "%d.%m.%Y",
   "time24": "%T",

--- a/src/locales/de_DE.js
+++ b/src/locales/de_DE.js
@@ -51,8 +51,8 @@ module.exports = {
     ]
   },
   "meridiem": [
-    "",
-    ""
+    "AM",
+    "PM"
   ],
   "date": "%d.%m.%Y",
   "time24": "%T",

--- a/src/locales/es_AR.js
+++ b/src/locales/es_AR.js
@@ -51,8 +51,8 @@ module.exports = {
     ]
   },
   "meridiem": [
-    "",
-    ""
+    "AM",
+    "PM"
   ],
   "date": "%d/%m/%y",
   "time24": "%T",

--- a/src/locales/es_CL.js
+++ b/src/locales/es_CL.js
@@ -51,8 +51,8 @@ module.exports = {
     ]
   },
   "meridiem": [
-    "",
-    ""
+    "AM",
+    "PM"
   ],
   "date": "%d/%m/%y",
   "time24": "%T",

--- a/src/locales/es_EC.js
+++ b/src/locales/es_EC.js
@@ -51,8 +51,8 @@ module.exports = {
     ]
   },
   "meridiem": [
-    "",
-    ""
+    "AM",
+    "PM"
   ],
   "date": "%d/%m/%y",
   "time24": "%T",

--- a/src/locales/es_ES.js
+++ b/src/locales/es_ES.js
@@ -51,8 +51,8 @@ module.exports = {
     ]
   },
   "meridiem": [
-    "",
-    ""
+    "AM",
+    "PM"
   ],
   "date": "%d/%m/%y",
   "time24": "%T",

--- a/src/locales/es_GT.js
+++ b/src/locales/es_GT.js
@@ -51,8 +51,8 @@ module.exports = {
     ]
   },
   "meridiem": [
-    "",
-    ""
+    "AM",
+    "PM"
   ],
   "date": "%d/%m/%y",
   "time24": "%T",

--- a/src/locales/es_HN.js
+++ b/src/locales/es_HN.js
@@ -51,8 +51,8 @@ module.exports = {
     ]
   },
   "meridiem": [
-    "",
-    ""
+    "AM",
+    "PM"
   ],
   "date": "%d/%m/%y",
   "time24": "%T",

--- a/src/locales/es_MX.js
+++ b/src/locales/es_MX.js
@@ -51,8 +51,8 @@ module.exports = {
     ]
   },
   "meridiem": [
-    "",
-    ""
+    "AM",
+    "PM"
   ],
   "date": "%d/%m/%y",
   "time24": "%T",

--- a/src/locales/es_PA.js
+++ b/src/locales/es_PA.js
@@ -51,8 +51,8 @@ module.exports = {
     ]
   },
   "meridiem": [
-    "",
-    ""
+    "AM",
+    "PM"
   ],
   "date": "%d/%m/%y",
   "time24": "%T",

--- a/src/locales/es_PR.js
+++ b/src/locales/es_PR.js
@@ -51,8 +51,8 @@ module.exports = {
     ]
   },
   "meridiem": [
-    "",
-    ""
+    "AM",
+    "PM"
   ],
   "date": "%d/%m/%y",
   "time24": "%T",

--- a/src/locales/es_SV.js
+++ b/src/locales/es_SV.js
@@ -51,8 +51,8 @@ module.exports = {
     ]
   },
   "meridiem": [
-    "",
-    ""
+    "AM",
+    "PM"
   ],
   "date": "%d/%m/%y",
   "time24": "%T",

--- a/src/locales/es_UY.js
+++ b/src/locales/es_UY.js
@@ -51,8 +51,8 @@ module.exports = {
     ]
   },
   "meridiem": [
-    "",
-    ""
+    "AM",
+    "PM"
   ],
   "date": "%d/%m/%y",
   "time24": "%T",

--- a/src/locales/eu_ES.js
+++ b/src/locales/eu_ES.js
@@ -51,8 +51,8 @@ module.exports = {
     ]
   },
   "meridiem": [
-    "",
-    ""
+    "AM",
+    "PM"
   ],
   "date": "%a, %Y.eko %bren %da",
   "time24": "%T",

--- a/src/locales/fi_FI.js
+++ b/src/locales/fi_FI.js
@@ -51,8 +51,8 @@ module.exports = {
     ]
   },
   "meridiem": [
-    "",
-    ""
+    "AM",
+    "PM"
   ],
   "date": "%d.%m.%Y",
   "time24": "%H.%M.%S",

--- a/src/locales/fr_BE.js
+++ b/src/locales/fr_BE.js
@@ -51,8 +51,8 @@ module.exports = {
     ]
   },
   "meridiem": [
-    "",
-    ""
+    "AM",
+    "PM"
   ],
   "date": "%d/%m/%y",
   "time24": "%T",

--- a/src/locales/fr_CA.js
+++ b/src/locales/fr_CA.js
@@ -51,8 +51,8 @@ module.exports = {
     ]
   },
   "meridiem": [
-    "",
-    ""
+    "AM",
+    "PM"
   ],
   "date": "%Y-%m-%d",
   "time24": "%T",

--- a/src/locales/fr_CH.js
+++ b/src/locales/fr_CH.js
@@ -51,8 +51,8 @@ module.exports = {
     ]
   },
   "meridiem": [
-    "",
-    ""
+    "AM",
+    "PM"
   ],
   "date": "%d. %m. %y",
   "time24": "%T",

--- a/src/locales/fr_FR.js
+++ b/src/locales/fr_FR.js
@@ -51,8 +51,8 @@ module.exports = {
     ]
   },
   "meridiem": [
-    "",
-    ""
+    "AM",
+    "PM"
   ],
   "date": "%d/%m/%Y",
   "time24": "%T",

--- a/src/locales/gl_ES.js
+++ b/src/locales/gl_ES.js
@@ -51,8 +51,8 @@ module.exports = {
     ]
   },
   "meridiem": [
-    "",
-    ""
+    "AM",
+    "PM"
   ],
   "date": "%d/%m/%y",
   "time24": "%T",

--- a/src/locales/hr_HR.js
+++ b/src/locales/hr_HR.js
@@ -51,8 +51,8 @@ module.exports = {
     ]
   },
   "meridiem": [
-    "",
-    ""
+    "AM",
+    "PM"
   ],
   "date": "%d.%m.%Y",
   "time24": "%T",

--- a/src/locales/hu_HU.js
+++ b/src/locales/hu_HU.js
@@ -51,8 +51,8 @@ module.exports = {
     ]
   },
   "meridiem": [
-    "",
-    ""
+    "AM",
+    "PM"
   ],
   "date": "%Y-%m-%d",
   "time24": "%H.%M.%S",

--- a/src/locales/id_ID.js
+++ b/src/locales/id_ID.js
@@ -51,8 +51,8 @@ module.exports = {
     ]
   },
   "meridiem": [
-    "",
-    ""
+    "AM",
+    "PM"
   ],
   "date": "%d/%m/%y",
   "time24": "%T",

--- a/src/locales/it_CH.js
+++ b/src/locales/it_CH.js
@@ -51,8 +51,8 @@ module.exports = {
     ]
   },
   "meridiem": [
-    "",
-    ""
+    "AM",
+    "PM"
   ],
   "date": "%d. %m. %y",
   "time24": "%T",

--- a/src/locales/it_IT.js
+++ b/src/locales/it_IT.js
@@ -51,8 +51,8 @@ module.exports = {
     ]
   },
   "meridiem": [
-    "",
-    ""
+    "AM",
+    "PM"
   ],
   "date": "%d/%m/%Y",
   "time24": "%T",

--- a/src/locales/lt_LT.js
+++ b/src/locales/lt_LT.js
@@ -51,8 +51,8 @@ module.exports = {
     ]
   },
   "meridiem": [
-    "",
-    ""
+    "AM",
+    "PM"
   ],
   "date": "%Y.%m.%d",
   "time24": "%T",

--- a/src/locales/lv_LV.js
+++ b/src/locales/lv_LV.js
@@ -51,8 +51,8 @@ module.exports = {
     ]
   },
   "meridiem": [
-    "",
-    ""
+    "AM",
+    "PM"
   ],
   "date": "%Y.%m.%d.",
   "time24": "%T",

--- a/src/locales/ms_MY.js
+++ b/src/locales/ms_MY.js
@@ -51,8 +51,8 @@ module.exports = {
     ]
   },
   "meridiem": [
-    "",
-    ""
+    "AM",
+    "PM"
   ],
   "date": "%A %d %b %Y",
   "time24": "%I:%M:%S  %Z",

--- a/src/locales/nb_NO.js
+++ b/src/locales/nb_NO.js
@@ -51,8 +51,8 @@ module.exports = {
     ]
   },
   "meridiem": [
-    "",
-    ""
+    "AM",
+    "PM"
   ],
   "date": "%d. %b %Y",
   "time24": "kl. %H.%M %z",

--- a/src/locales/nds_DE.js
+++ b/src/locales/nds_DE.js
@@ -51,8 +51,8 @@ module.exports = {
     ]
   },
   "meridiem": [
-    "",
-    ""
+    "AM",
+    "PM"
   ],
   "date": "%d.%m.%Y",
   "time24": "%T",

--- a/src/locales/nl_BE.js
+++ b/src/locales/nl_BE.js
@@ -51,8 +51,8 @@ module.exports = {
     ]
   },
   "meridiem": [
-    "",
-    ""
+    "AM",
+    "PM"
   ],
   "date": "%d-%m-%y",
   "time24": "%T",

--- a/src/locales/nl_NL.js
+++ b/src/locales/nl_NL.js
@@ -51,8 +51,8 @@ module.exports = {
     ]
   },
   "meridiem": [
-    "",
-    ""
+    "AM",
+    "PM"
   ],
   "date": "%d-%m-%y",
   "time24": "%T",

--- a/src/locales/pl_PL.js
+++ b/src/locales/pl_PL.js
@@ -51,8 +51,8 @@ module.exports = {
     ]
   },
   "meridiem": [
-    "",
-    ""
+    "AM",
+    "PM"
   ],
   "date": "%d.%m.%Y",
   "time24": "%T",

--- a/src/locales/pt_BR.js
+++ b/src/locales/pt_BR.js
@@ -51,8 +51,8 @@ module.exports = {
     ]
   },
   "meridiem": [
-    "",
-    ""
+    "AM",
+    "PM"
   ],
   "date": "%d-%m-%Y",
   "time24": "%T",

--- a/src/locales/pt_PT.js
+++ b/src/locales/pt_PT.js
@@ -51,8 +51,8 @@ module.exports = {
     ]
   },
   "meridiem": [
-    "",
-    ""
+    "AM",
+    "PM"
   ],
   "date": "%d-%m-%Y",
   "time24": "%T",

--- a/src/locales/ru_RU.js
+++ b/src/locales/ru_RU.js
@@ -51,8 +51,8 @@ module.exports = {
     ]
   },
   "meridiem": [
-    "",
-    ""
+    "AM",
+    "PM"
   ],
   "date": "%d.%m.%Y",
   "time24": "%T",

--- a/src/locales/sk_SK.js
+++ b/src/locales/sk_SK.js
@@ -51,8 +51,8 @@ module.exports = {
     ]
   },
   "meridiem": [
-    "",
-    ""
+    "AM",
+    "PM"
   ],
   "date": "%d. %m. %Y",
   "time24": "%T",

--- a/src/locales/sl_SI.js
+++ b/src/locales/sl_SI.js
@@ -51,8 +51,8 @@ module.exports = {
     ]
   },
   "meridiem": [
-    "",
-    ""
+    "AM",
+    "PM"
   ],
   "date": "%d. %m. %Y",
   "time24": "%T",

--- a/src/locales/sr_RS.js
+++ b/src/locales/sr_RS.js
@@ -51,8 +51,8 @@ module.exports = {
     ]
   },
   "meridiem": [
-    "",
-    ""
+    "AM",
+    "PM"
   ],
   "date": "%d.%m.%Y.",
   "time24": "%T",

--- a/src/locales/sv_SE.js
+++ b/src/locales/sv_SE.js
@@ -51,8 +51,8 @@ module.exports = {
     ]
   },
   "meridiem": [
-    "",
-    ""
+    "AM",
+    "PM"
   ],
   "date": "%Y-%m-%d",
   "time24": "%H:%M:%S",

--- a/src/locales/uk_UA.js
+++ b/src/locales/uk_UA.js
@@ -51,8 +51,8 @@ module.exports = {
     ]
   },
   "meridiem": [
-    "",
-    ""
+    "AM",
+    "PM"
   ],
   "date": "%d.%m.%y",
   "time24": "%T",

--- a/t/locale/ms_MY/formats.t.js
+++ b/t/locale/ms_MY/formats.t.js
@@ -9,6 +9,6 @@ require('proof')(5, function (assert) {
     assert(tz('2000-09-03 23:05:04', '%X', 'ms_MY'), '11:05:04  UTC', 'long time format evening')
 
     // ms_MY date time representation
-    assert(tz('2000-09-03 08:05:04', '%c', 'ms_MY'), 'Ahad 03 Sep 2000 08:05:04  UTC', 'long date format morning')
-    assert(tz('2000-09-03 23:05:04', '%c', 'ms_MY'), 'Ahad 03 Sep 2000 11:05:04  UTC', 'long date format evening')
+    assert(tz('2000-09-03 08:05:04', '%c', 'ms_MY'), 'Ahad 03 Sep 2000 08:05:04 AM UTC', 'long date format morning')
+    assert(tz('2000-09-03 23:05:04', '%c', 'ms_MY'), 'Ahad 03 Sep 2000 11:05:04 PM UTC', 'long date format evening')
 })


### PR DESCRIPTION
Update: tests pass as expected locally and in the jenkins. Thank you @bigeasy for fixing ci issue. 

Test steps locally: 

using node@12

1. `git clone https://github.com/bigeasy/timezone.git`
2. `git submodule update --init --recursive`
3. `make`
4. `npm i`
5. `npm t`

Closes https://github.com/bigeasy/timezone/issues/331

If a user is expecting to not get a meridiem because the locale previously didn't support it, then they would not get it if they elected for that format

Updated test steps and docs in #333 

------------------ 

the tests did not seem to be passing for me locally so I wasn't sure if the failing was as expected

from master: 

```
> ✘ t/format/abbrev.t.js: Bail Out!
# Error: Cannot find module 'timezone/America/Anchorage'
#     at Function.Module._resolveFilename (internal/modules/cjs/loader.js:582:15)
#     at Function.Module._load (internal/modules/cjs/loader.js:508:25)
#     at Module.require (internal/modules/cjs/loader.js:637:17)
#     at require (internal/modules/cjs/helpers.js:22:18)
#     at prove (/Users/howardj/sites/learning/timezone/t/format/abbrev.t.js:5:13)
#     at /Users/howardj/sites/learning/timezone/node_modules/proof/scaffold.js:31:19
#     at module.exports (/Users/howardj/sites/learning/timezone/node_modules/proof/index.js:13:9)
#     at Object.<anonymous> (/Users/howardj/sites/learning/timezone/t/format/abbrev.t.js:1:79)
#     at Module._compile (internal/modules/cjs/loader.js:701:30)
#     at Object.Module._extensions..js (internal/modules/cjs/loader.js:712:10)
> ✘ t/format/abbrev.t.js: expected 1 test but got 0: exited with code 1

>--

...